### PR TITLE
Check the state (#509)

### DIFF
--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -26,6 +26,7 @@ def prompt_for_user_token(
     client_id=None,
     client_secret=None,
     redirect_uri=None,
+    state=None,
     cache_path=None,
     oauth_manager=None,
     show_dialog=False
@@ -84,6 +85,7 @@ def prompt_for_user_token(
         client_id,
         client_secret,
         redirect_uri,
+        state=state,
         scope=scope,
         cache_path=cache_path,
         show_dialog=show_dialog


### PR DESCRIPTION
* - Verify that the state received alongside the authorization code is consistent with the one sent
- Refactor URL parsing for the local server way and the interactive way
- Add tests for interactive way

* Resurrect public methods parse_response_code and get_authorization_code

* Use new method parse_oatuh_response_url for parse_response_code implementation.